### PR TITLE
support for retina displays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,5 +90,6 @@ if (SystemUtils.IS_OS_MAC) {
 		icon = new File(project.projectDir, '/package/osx/icon.icns')
 		bundleJRE = true
 		javaProperties.put("apple.laf.useScreenMenuBar", "true")
+		bundleExtras.put("NSHighResolutionCapable", "true")
 	}
 }


### PR DESCRIPTION
Changed macAppBundle configuration to include `NSHighResolutionCapable=true` into application Info.plist. 
As a result we get nicer looking fonts on retina displays.

I'm not sure if this is THE FORK to send pull requests to, but it certainly seems most up-to-date and active one.
